### PR TITLE
🐛 htmlproofer 5.x CLI 호환 수정

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Test site
         run: |
           bundle exec htmlproofer _site \
-            \-\-disable-external=true \
-            \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
+            --disable-external \
+            --ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
PR #75 머지 후 CI 빌드 실패. `html-proofer` 5.x에서 `--disable-external=true` 인자 형식이 제거되어 `--disable-external` (인자 없음)으로 변경.

## Root cause
이전 워크플로우가 `--disable-external=true`를 사용하던 부분이 chirpy v6 시절 html-proofer 4.x 컨벤션. v7.5 업그레이드와 함께 html-proofer가 5.x로 올라가면서 `OptionParser::NeedlessArgument` 발생.

## Test plan
- [ ] CI에서 `bundle exec htmlproofer _site --disable-external` 정상 실행
- [ ] GitHub Pages 배포 성공